### PR TITLE
Poprawka dla pełnych kwot (bez groszy)

### DIFF
--- a/src/KwotaSlownie.php
+++ b/src/KwotaSlownie.php
@@ -56,7 +56,11 @@ class KwotaSlownie {
         $amountString = (string) round($amount, 2);
         $numbers = explode('.', $amountString);
         $zlotys = $numbers[0];
-        $groszes = strlen($numbers[1]) === 1 ? $numbers[1] * 10 : $numbers[1]; // naprawia błąd w przypadku kwoty 2.2 (jako 2 grosze, a nie 20)
+        $groszes = 0;
+
+        if (isset($numbers[1])) {
+            $groszes = strlen($numbers[1]) === 1 ? $numbers[1] * 10 : $numbers[1]; // naprawia błąd w przypadku kwoty 2.2 (jako 2 grosze, a nie 20)
+        }
 
         $output = "{$numberFormatter->format($zlotys)} {$this->selectWordVariety([self::ONE_ZLOTY, self::TWO_ZLOTYS, self::FIVE_ZLOTYS], $zlotys)}";
         $output .= $isComma ? ", " : " ";


### PR DESCRIPTION
W obecnej wersji kwota typu 25000 wykrzacza się w miejscu ustawiania zmiennej $groszes.
Kiedy grosze są równe 0, $amountString będzie liczbą całkowitą, a $numbers będzie miało tylko jeden element, co spowoduje błąd przy próbie odczytu $numbers[1].